### PR TITLE
Show messages when rn editing is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The configuration is overridable by environment variables, expressed between []:
 - `iDEditor` - The address of the iDEditor. Defaults to the `master` branch of the [RAM fork of iD](https://github.com/WorldBank-Transport/ram-id), hosted on GH Pages. (Default: https://id.ruralaccess.info). [IDEDITOR]
 - `mbtoken` - The Mapbox Token to load map tiles from. [MBTOKEN]
 - `rahUrl` - The url for the Rural Accessibility Hub. [RAH_URL]
+- `roadNetEditMax` - Maximum value over which the road network editing is disabled. Must match the value of the same config on the backend. [ROAD_NET_EDIT_MAX]
 - `auth` - The configuration for optional authentication with Auth0. By default, no authentication is set (Default: {})
 - `auth.domain` - See instructions below [AUTH_DOMAIN]
 - `auth.clientID` - See instructions below [AUTH_CLIENTID]

--- a/app/assets/scripts/components/project/source-modals/catalog-source.js
+++ b/app/assets/scripts/components/project/source-modals/catalog-source.js
@@ -85,7 +85,16 @@ export class CatalogSource extends React.Component {
       return <p>{t('An error occurred getting data from World Bank Catalog.')}</p>;
     }
 
-    if (!options) return null; // Is loading.
+    if (!options) {
+      // Is loading.
+      return (
+        <div className='form__group'>
+          <select id='wbc-profile' name='wbc-profile' className='form__control' disabled>
+            <option>Loading data</option>
+          </select>
+        </div>
+      );
+    }
 
     if (!options.length) {
       return <p>{t('There are options available in the World Bank Catalog.')}</p>;

--- a/app/assets/scripts/components/project/source-modals/modal-road-network.js
+++ b/app/assets/scripts/components/project/source-modals/modal-road-network.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 
 import config from '../../../config';
 import { t } from '../../../utils/i18n';
-import { rnEditThreshold, rnEditThresholdDisplay } from '../../../utils/constants';
+import { roadNetEditMax, roadNetEditMaxDisplay } from '../../../utils/constants';
 import { postFormdata, fetchJSON } from '../../../actions';
 import { showGlobalLoading, hideGlobalLoading } from '../../global-loading';
 
@@ -72,9 +72,9 @@ class ModalRoadNetwork extends ModalBase {
 
     this.setState({ fileField });
 
-    if (rnEditThreshold > 0 && file.size >= rnEditThreshold) {
+    if (roadNetEditMax > 0 && file.size >= roadNetEditMax) {
       let msg = t('File size is above {size}. Road network editing will be disabled.', {
-        size: rnEditThresholdDisplay
+        size: roadNetEditMaxDisplay
       });
       this.props._showAlert('warning', <p>{msg}</p>, true);
     }
@@ -251,10 +251,10 @@ class ModalRoadNetwork extends ModalBase {
       notes.push(<p key='rn-osm'>{t('Import road network data for the project\'s Administrative Boundaries from OpenStreetMap. For more fine-grained control, upload a file with custom road network data.')}</p>);
     }
 
-    if (rnEditThreshold <= 0) {
+    if (roadNetEditMax <= 0) {
       notes.push(<p key='rn-disabled'>{t('Road network editing was disabled by the administrator.')}</p>);
     } else if (this.state.source === 'osm') {
-      notes.push(<p key='rn-osm-thresh'>{t('When the resulting import is over {max} the road network editing will be disabled.', {max: rnEditThresholdDisplay})}</p>);
+      notes.push(<p key='rn-osm-thresh'>{t('When the resulting import is over {max} the road network editing will be disabled.', {max: roadNetEditMaxDisplay})}</p>);
     }
 
     return (

--- a/app/assets/scripts/components/project/source-modals/modal-road-network.js
+++ b/app/assets/scripts/components/project/source-modals/modal-road-network.js
@@ -72,7 +72,7 @@ class ModalRoadNetwork extends ModalBase {
 
     this.setState({ fileField });
 
-    if (file.size >= rnEditThreshold) {
+    if (rnEditThreshold > 0 && file.size >= rnEditThreshold) {
       let msg = t('File size is above {size}. Road network editing will be disabled.', {
         size: rnEditThresholdDisplay
       });
@@ -245,6 +245,18 @@ class ModalRoadNetwork extends ModalBase {
       {id: 'wbcatalog', name: t('WB Catalog')}
     ];
 
+    let notes = [];
+
+    if (this.state.source === 'osm') {
+      notes.push(<p key='rn-osm'>{t('Import road network data for the project\'s Administrative Boundaries from OpenStreetMap. For more fine-grained control, upload a file with custom road network data.')}</p>);
+    }
+
+    if (rnEditThreshold <= 0) {
+      notes.push(<p key='rn-disabled'>{t('Road network editing was disabled by the administrator.')}</p>);
+    } else if (this.state.source === 'osm') {
+      notes.push(<p key='rn-osm-thresh'>{t('When the resulting import is over {max} the road network editing will be disabled.', {max: rnEditThresholdDisplay})}</p>);
+    }
+
     return (
       <ModalBody>
         <form className='form' onSubmit={ e => { e.preventDefault(); this.allowSubmit() && this.onSubmit(); } }>
@@ -256,8 +268,8 @@ class ModalRoadNetwork extends ModalBase {
               onChange={this.onSourceChange} />
           </div>
           {this.state.source === 'file' ? this.renderSourceFile() : null}
-          {this.state.source === 'osm' && <div className='form__note'><p>{t('Import road network data for the project\'s Administrative Boundaries from OpenStreetMap. For more fine-grained control, upload a file with custom road network data.')}</p><p>{t('When the resulting import is over {max} the road network editing will be disabled.', {max: rnEditThresholdDisplay})}</p></div>}
           {this.state.source === 'wbcatalog' ? this.renderSourceCatalog() : null}
+          {!!notes.length && <div className='form__note'>{notes}</div>}
         </form>
       </ModalBody>
     );

--- a/app/assets/scripts/components/scenario/scenario-create-modal.js
+++ b/app/assets/scripts/components/scenario/scenario-create-modal.js
@@ -118,7 +118,7 @@ const ScenarioCreateModal = React.createClass({
     let data = Object.assign({}, this.state.data, {roadNetworkSourceFile});
     this.setState({data});
 
-    if (file.size >= rnEditThreshold) {
+    if (rnEditThreshold > 0 && file.size >= rnEditThreshold) {
       let msg = t('File size is above {size}. Road network editing will be disabled.', {
         size: rnEditThresholdDisplay
       });
@@ -282,6 +282,17 @@ const ScenarioCreateModal = React.createClass({
 
   render: function () {
     let processing = this.props.scenarioForm.processing || this.state.loading;
+    let notes = [];
+
+    if (this.state.data.roadNetworkSource === 'osm') {
+      notes.push(<p key='rn-osm'>{t('Import road network data from OpenStreetMap.')}</p>);
+    }
+
+    if (rnEditThreshold <= 0) {
+      notes.push(<p key='rn-disabled'>{t('Road network editing was disabled by the administrator.')}</p>);
+    } else if (this.state.data.roadNetworkSource === 'osm') {
+      notes.push(<p key='rn-osm-thresh'>{t('When the resulting import is over {max} the road network editing will be disabled.', {max: rnEditThresholdDisplay})}</p>);
+    }
 
     const sourceOptions = [
       {id: 'clone', name: t('Clone from scenario')},
@@ -346,7 +357,7 @@ const ScenarioCreateModal = React.createClass({
             </FileInput>
             ) : null}
 
-            {this.state.data.roadNetworkSource === 'osm' && <div className='form__note'><p>{t('Import road network data from OpenStreetMap.')}</p><p>{t('When the resulting import is over {max} the road network editing will be disabled.', {max: rnEditThresholdDisplay})}</p></div>}
+            {!!notes.length && <div className='form__note'>{notes}</div>}
 
             {this.state.data.roadNetworkSource === 'wbcatalog' ? this.renderSourceCatalog() : null}
 

--- a/app/assets/scripts/components/scenario/scenario-create-modal.js
+++ b/app/assets/scripts/components/scenario/scenario-create-modal.js
@@ -7,7 +7,7 @@ import ReactTooltip from 'react-tooltip';
 
 import config from '../../config';
 import { t, getLanguage } from '../../utils/i18n';
-import { rnEditThreshold, rnEditThresholdDisplay } from '../../utils/constants';
+import { roadNetEditMax, roadNetEditMaxDisplay } from '../../utils/constants';
 import { limitHelper } from '../../utils/utils';
 import { postFormdata } from '../../actions';
 import SourceSelector from '../project/source-modals/source-selector';
@@ -118,9 +118,9 @@ const ScenarioCreateModal = React.createClass({
     let data = Object.assign({}, this.state.data, {roadNetworkSourceFile});
     this.setState({data});
 
-    if (rnEditThreshold > 0 && file.size >= rnEditThreshold) {
+    if (roadNetEditMax > 0 && file.size >= roadNetEditMax) {
       let msg = t('File size is above {size}. Road network editing will be disabled.', {
-        size: rnEditThresholdDisplay
+        size: roadNetEditMaxDisplay
       });
       this.props._showAlert('warning', <p>{msg}</p>, true);
     }
@@ -288,10 +288,10 @@ const ScenarioCreateModal = React.createClass({
       notes.push(<p key='rn-osm'>{t('Import road network data from OpenStreetMap.')}</p>);
     }
 
-    if (rnEditThreshold <= 0) {
+    if (roadNetEditMax <= 0) {
       notes.push(<p key='rn-disabled'>{t('Road network editing was disabled by the administrator.')}</p>);
     } else if (this.state.data.roadNetworkSource === 'osm') {
-      notes.push(<p key='rn-osm-thresh'>{t('When the resulting import is over {max} the road network editing will be disabled.', {max: rnEditThresholdDisplay})}</p>);
+      notes.push(<p key='rn-osm-thresh'>{t('When the resulting import is over {max} the road network editing will be disabled.', {max: roadNetEditMaxDisplay})}</p>);
     }
 
     const sourceOptions = [
@@ -357,9 +357,9 @@ const ScenarioCreateModal = React.createClass({
             </FileInput>
             ) : null}
 
-            {!!notes.length && <div className='form__note'>{notes}</div>}
-
             {this.state.data.roadNetworkSource === 'wbcatalog' ? this.renderSourceCatalog() : null}
+
+            {!!notes.length && <div className='form__note'>{notes}</div>}
 
             <div className='form__group'>
               <label className='form__label'>{t('Points of Interest')}</label>

--- a/app/assets/scripts/components/scenario/scenario-header-actions.js
+++ b/app/assets/scripts/components/scenario/scenario-header-actions.js
@@ -7,12 +7,14 @@ import config from '../../config';
 import Dropdown from '../dropdown';
 import { t } from '../../utils/i18n';
 import { scenarioHasResults } from '../../utils/utils';
+import { rnEditThreshold } from '../../utils/constants';
 import { showConfirm } from '../confirmation-prompt';
 
 import ScenarioDeleteAction from './scenario-delete-action';
 
 const tipTexts = {
   rnNotAllowed: t('Road network is too big and can\'t be edited.'),
+  rnDisabled: t('Road network editing was disabled by the administrator.'),
   generating: t('Generation is in progress.'),
   pending: t('Scenario still being created.')
 };
@@ -50,7 +52,8 @@ const ScenarioHeaderActions = React.createClass({
     let txt;
 
     if (!isRnAllowed) {
-      txt = tipTexts.rnNotAllowed;
+      // Different message is the rn edition was disabled via constants.
+      txt = rnEditThreshold <= 0 ? tipTexts.rnDisabled : tipTexts.rnNotAllowed;
     } else if (isGenerating) {
       txt = tipTexts.generating;
     } else if (isPending) {

--- a/app/assets/scripts/components/scenario/scenario-header-actions.js
+++ b/app/assets/scripts/components/scenario/scenario-header-actions.js
@@ -7,7 +7,7 @@ import config from '../../config';
 import Dropdown from '../dropdown';
 import { t } from '../../utils/i18n';
 import { scenarioHasResults } from '../../utils/utils';
-import { rnEditThreshold } from '../../utils/constants';
+import { roadNetEditMax } from '../../utils/constants';
 import { showConfirm } from '../confirmation-prompt';
 
 import ScenarioDeleteAction from './scenario-delete-action';
@@ -53,7 +53,7 @@ const ScenarioHeaderActions = React.createClass({
 
     if (!isRnAllowed) {
       // Different message is the rn edition was disabled via constants.
-      txt = rnEditThreshold <= 0 ? tipTexts.rnDisabled : tipTexts.rnNotAllowed;
+      txt = roadNetEditMax <= 0 ? tipTexts.rnDisabled : tipTexts.rnNotAllowed;
     } else if (isGenerating) {
       txt = tipTexts.generating;
     } else if (isPending) {

--- a/app/assets/scripts/config.js
+++ b/app/assets/scripts/config.js
@@ -20,6 +20,7 @@ config.api = process.env.API || config.api;
 config.iDEditor = process.env.IDEDITOR || config.iDEditor;
 config.mbtoken = process.env.MBTOKEN || config.mbtoken;
 config.rahUrl = process.env.RAH_URL || config.rahUrl;
+config.roadNetEditMax = process.env.ROAD_NET_EDIT_MAX || config.roadNetEditMax;
 
 // auth is an empty object, unless one of the environment vars is set
 if (process.env.AUTH_DOMAIN) config.auth.domain = process.env.AUTH_DOMAIN;

--- a/app/assets/scripts/config/base.js
+++ b/app/assets/scripts/config/base.js
@@ -7,5 +7,8 @@ module.exports = {
   iDEditor: 'http://id.ruralaccess.info',
   mbtoken: null,
   rahUrl: null,
-  auth: {}
+  auth: {},
+  // Set value to 0 to disable rn editing. Must also be disabled in backend.
+  // Value in bytes.
+  roadNetEditMax: 20 * Math.pow(1024, 2)
 };

--- a/app/assets/scripts/config/offline.js
+++ b/app/assets/scripts/config/offline.js
@@ -7,5 +7,8 @@ module.exports = {
   api: 'http://localhost:4000',
   iDEditor: 'http://localhost:8000',
   mbtoken: 'pk.eyJ1IjoicnVyYWxyb2FkcyIsImEiOiJjajlmbTBzN3IyaWVyMndwYTJ3dzFnYjhwIn0.1z7NRCrUVWStt5YURX_HGg',
-  rahUrl: 'http://rah.surge.sh'
+  rahUrl: 'http://rah.surge.sh',
+  // Set value to 0 to disable rn editing. Must also be disabled in backend.
+  // Value in bytes.
+  roadNetEditMax: 20 * Math.pow(1024, 2)
 };

--- a/app/assets/scripts/utils/constants.js
+++ b/app/assets/scripts/utils/constants.js
@@ -1,7 +1,8 @@
 'use strict';
 import { t } from '../utils/i18n';
 
-let rnEditThresholdVal = 20; // MB
+// Set value to 0 to disable rn editing. Must also be disabled in backend.
+let rnEditThresholdVal = 0; // MB
 export const rnEditThreshold = rnEditThresholdVal * Math.pow(1024, 2); // bytes
 export const rnEditThresholdDisplay = `${rnEditThresholdVal}MB`;
 

--- a/app/assets/scripts/utils/constants.js
+++ b/app/assets/scripts/utils/constants.js
@@ -1,10 +1,9 @@
 'use strict';
 import { t } from '../utils/i18n';
+import { roadNetEditMax as rnConfMax } from '../config';
 
-// Set value to 0 to disable rn editing. Must also be disabled in backend.
-let rnEditThresholdVal = 0; // MB
-export const rnEditThreshold = rnEditThresholdVal * Math.pow(1024, 2); // bytes
-export const rnEditThresholdDisplay = `${rnEditThresholdVal}MB`;
+export const roadNetEditMax = rnConfMax;
+export const roadNetEditMaxDisplay = `${rnConfMax / Math.pow(1024, 2)}MB`;
 
 // These constants need to be returned as the result of a function because, the
 // translations need to be computed based on the current language. Otherwise


### PR DESCRIPTION
When setting the `rnEditThreshold` value to 0 in `scripts/utils/constants`, the RN editing is disabled and the message `Road network editing was disabled by the administrator.` is shown.

Note that the editing of the RN must also be disabled on the backend.